### PR TITLE
Fix py-lief being dropped as dependency on Windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - conda-build = conda_build.cli.main_build:main
     - conda-convert = conda_build.cli.main_convert:main
@@ -39,7 +39,7 @@ requirements:
     - patchelf      # [linux]
     - pkginfo
     - psutil
-    - py-lief  # [not win]
+    - py-lief
     - python
     - pyyaml
     - python-libarchive-c


### PR DESCRIPTION
Update to recipe for 3.21.7 mistakenly `py-lief  # [not (win and py2k)]` to `py-lief  # [not win]` when removing py2.7-related cruft. This only requires a re-build for Windows; the Linux and macOS builds should be fine.