### PR TITLE
Bump version to 3.22.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
     - conda-package-handling >=1.3
     - wheel
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,7 @@ requirements:
     - patchelf      # [linux]
     - patch     >=2.6   # [not win]
     - m2-patch  >=2.6   # [win]
+    - pip
     - pkginfo
     - psutil
     - py-lief
@@ -55,6 +56,7 @@ requirements:
     - setuptools
     - six
     - tqdm
+    - wheel
 
   run_constrained:
     - conda-verify >=3.1.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,6 @@ requirements:
     - patchelf      # [linux]
     - patch     >=2.6   # [not win]
     - m2-patch  >=2.6   # [win]
-    - pip
     - pkginfo
     - psutil
     - py-lief

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,26 +33,26 @@ requirements:
     - conda-package-handling >=1.3
     - wheel
   run:
-    - conda >=4.5
-    - requests
-    - conda-package-handling >=1.3
-    - filelock
-    - pyyaml
-    - jinja2
-    - pkginfo
     - beautifulsoup4
     - chardet
-    - pytz
-    - tqdm
-    - psutil
-    - six
-    - python-libarchive-c
-    - setuptools
+    - conda >=4.5
+    - conda-package-handling >=1.3
+    - filelock
+    - glob2 >=0.6
+    - jinja2
     - patchelf      # [linux]
+    - pkginfo
+    - psutil
     - py-lief
     - python
+    - python-libarchive-c
+    - pytz
+    - pyyaml
+    - requests
     - ripgrep            # [x86_64 and not win]
-    - glob2 >=0.6
+    - setuptools
+    - six
+    - tqdm
 
   run_constrained:
     - conda-verify >=3.1.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,8 @@ requirements:
     - glob2 >=0.6
     - jinja2
     - patchelf      # [linux]
+    - patch     >=2.6   # [not win]
+    - m2-patch  >=2.6   # [win]
     - pkginfo
     - psutil
     - py-lief

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,6 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
     - conda-package-handling >=1.3
     - wheel
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,6 @@ requirements:
     - patchelf      # [linux]
     - patch     >=2.6   # [not win]
     - m2-patch  >=2.6   # [win]
-    - pip
     - pkginfo
     - psutil
     - py-lief
@@ -60,12 +59,13 @@ requirements:
     - conda-verify >=3.1.0
 
 test:
-  # If you run the test suite (~10 min), these are required
-  # requires:
-  #   - pytest
-  #   - pytest-cov
-  #   - pytest-xdist
-  #   - pytest-env
+  requires:
+    - pip
+    # If you run the test suite (~10 min), these are required
+    # - pytest
+    # - pytest-cov
+    # - pytest-xdist
+    # - pytest-env
 
   files:
     - test_bdist_conda_setup.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda-build" %}
 {% set version = "3.22.0" %}
 {% set build_number = "0" %}
-{% set sha256 = "????" %}
+{% set sha256 = "d43407a10f383d9445f2fea55a870d6ad2bdb2265701f5da474e2abfa980d95c" %}
 
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,6 +42,7 @@ requirements:
     - patchelf      # [linux]
     - patch     >=2.6   # [not win]
     - m2-patch  >=2.6   # [win]
+    - pip
     - pkginfo
     - psutil
     - py-lief
@@ -54,7 +55,6 @@ requirements:
     - setuptools
     - six
     - tqdm
-    - wheel
 
   run_constrained:
     - conda-verify >=3.1.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
+  skip: True  # [py<36]
   number: {{ build_number }}
   entry_points:
     - conda-build = conda_build.cli.main_build:main
@@ -30,9 +31,11 @@ requirements:
     - python
     - pip
     - conda-package-handling >=1.3
+    - setuptools
     - wheel
   run:
     - beautifulsoup4
+    - cctools # [osx]
     - chardet
     - conda >=4.5
     - conda-package-handling >=1.3
@@ -53,6 +56,7 @@ requirements:
     - ripgrep            # [x86_64 and not win]
     - setuptools
     - six
+    - toml
     - tqdm
 
   run_constrained:
@@ -73,8 +77,12 @@ test:
   imports:
     - conda_build
     - conda_build.api
+    - conda_build.cli
     - conda_build.cli.main_build
     - conda_build.cli.main_render
+    - conda_build.jinja_context
+    - conda_build.os_utils
+    - conda_build.skeletons
 
   commands:
     # Check for all subcommands

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda-build" %}
-{% set version = "3.21.9" %}
+{% set version = "3.22.0" %}
 {% set build_number = "0" %}
-{% set sha256 = "19a5568e09ee476c7e9e68e00583f8ff1e4ca16b709e5078552156194ecd14ee" %}
+{% set sha256 = "????" %}
 
 
 package:
@@ -133,3 +133,4 @@ extra:
     - CJ-Wright
     - jezdez
     - chenghlee
+    - kenodegard


### PR DESCRIPTION
Bumps version for conda-build 3.22.0 release.

#17 used my fork and didn't appear to trigger Prefect workflows, trying without fork.