### PR TITLE
Bump to 3.28.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda-build" %}
-{% set version = "3.27.0" %}
+{% set version = "3.28.0" %}
 {% set build_number = "0" %}
-{% set sha256 = "2b59898a3d385d786e539e7b9eb012b2b4e50e757e5c4c840d68988990a5d9cc" %}
+{% set sha256 = "efc713ba0cfe75a9ef3c0a6b2e7455ca89c1e9d298f15b75d769c0c47cc2e67f" %}
 
 
 package:
@@ -47,10 +47,12 @@ requirements:
     - conda-package-handling >=1.3
     - filelock
     - jinja2
-    - patchelf      # [linux]
-    - patch     >=2.6   # [not win]
+    - jsonschema >=4.19
     - m2-patch  >=2.6   # [win]
+    - menuinst
     - packaging
+    - patch     >=2.6   # [not win]
+    - patchelf      # [linux]
     - pkginfo
     - psutil
     - py-lief
@@ -59,7 +61,6 @@ requirements:
     - pytz
     - pyyaml
     - requests
-    - six
     - tomli         # [py<311]
     - tqdm
   run_constrained:


### PR DESCRIPTION
- Remove unnecessary `six` package
- Sorts dependencies to mirror conda-build and conda-forge's recipes for easier maintenance
- Bump to latest version and update dependencies