### PR TITLE
Bump to 3.28.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda-build" %}
-{% set version = "3.28.1" %}
+{% set version = "3.28.2" %}
 {% set build_number = "0" %}
-{% set sha256 = "5df6757f2762574f26f66e0652f1cb0debb0079ed7b0f6732e612b3882e64967" %}
+{% set sha256 = "a2e580e70660be570b181b72652f4092e80136021e762a3b00e69e559e394d1e" %}
 
 
 package:


### PR DESCRIPTION
conda-build 3.28.2

**Destination channel:** defaults

### Links

- [PKG-3688](https://anaconda.atlassian.net/browse/PKG-3688) 
- [Upstream repository](https://github.com/conda/conda-build)
- [Upstream changelog/diff](https://github.com/conda/conda-build/releases/tag/3.28.2)
- Relevant dependency PRs:
  - n/a

### Explanation of changes:

- Corrects several regressions in conda-build 3.28.0

[PKG-3688]: https://anaconda.atlassian.net/browse/PKG-3688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ