### PR TITLE
conda-build v3.28.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda-build" %}
-{% set version = "3.28.2" %}
+{% set version = "3.28.3" %}
 {% set build_number = "0" %}
-{% set sha256 = "a2e580e70660be570b181b72652f4092e80136021e762a3b00e69e559e394d1e" %}
+{% set sha256 = "30d9cb6f3fd086e7060da01118c6ab08a6ad49baa9dbd6175d16bafbb5d9040d" %}
 
 
 package:


### PR DESCRIPTION
conda-build 3.28.3

**Destination channel:** defaults

### Links

- [PKG-3745](https://anaconda.atlassian.net/browse/PKG-3745) 
- [Upstream repository](github.com/conda/conda-build)
- [Upstream changelog/diff](https://github.com/conda/conda-build/releases/tag/3.28.3)
- Relevant dependency PRs:
  - n/a

### Explanation of changes:

- Bump to newest version


[PKG-3745]: https://anaconda.atlassian.net/browse/PKG-3745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ