### PR TITLE
24.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda-build" %}
-{% set version = "3.28.4" %}
+{% set version = "24.1.0" %}
 {% set build_number = "0" %}
-{% set sha256 = "ba223b4aaab88ba47ebbbeed15df373aaf10832e964dc574f3dc433e593dc271" %}
+{% set sha256 = "777430b8c85b1542df7bb10c140654d332a1fb37b219370151cd69dcbf073a88" %}
 
 
 package:
@@ -17,15 +17,14 @@ build:
   number: {{ build_number }}
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
-    - conda-build = conda_build.cli.main_build:main
-    - conda-convert = conda_build.cli.main_convert:main
-    - conda-debug = conda_build.cli.main_debug:main
-    - conda-develop = conda_build.cli.main_develop:main
-    - conda-index = conda_build.cli.main_index:main
-    - conda-inspect = conda_build.cli.main_inspect:main
-    - conda-metapackage = conda_build.cli.main_metapackage:main
-    - conda-render = conda_build.cli.main_render:main
-    - conda-skeleton = conda_build.cli.main_skeleton:main
+    - conda-build = conda_build.cli.main_build:execute
+    - conda-convert = conda_build.cli.main_convert:execute
+    - conda-debug = conda_build.cli.main_debug:execute
+    - conda-develop = conda_build.cli.main_develop:execute
+    - conda-inspect = conda_build.cli.main_inspect:execute
+    - conda-metapackage = conda_build.cli.main_metapackage:execute
+    - conda-render = conda_build.cli.main_render:execute
+    - conda-skeleton = conda_build.cli.main_skeleton:execute
 
 requirements:
   build:
@@ -49,7 +48,7 @@ requirements:
     - jinja2
     - jsonschema >=4.19
     - m2-patch  >=2.6   # [win]
-    - menuinst
+    - menuinst >=2
     - packaging
     - patch     >=2.6   # [not win]
     - patchelf      # [linux]
@@ -79,12 +78,11 @@ test:
     - test_bdist_conda_setup.py
   commands:
     - python -m pip check
-    # builtin subcommands
+    # subcommands
     - conda --help
     - conda build --help
     - conda convert --help
     - conda develop --help
-    - conda index --help
     - conda inspect --help
     - conda inspect linkages --help  # [unix]
     - conda inspect objects --help  # [osx]
@@ -92,6 +90,17 @@ test:
     - conda render --help
     - conda skeleton --help
     - conda debug --help
+    # entrypoints
+    - conda-build --help
+    - conda-convert --help
+    - conda-develop --help
+    - conda-inspect --help
+    - conda-inspect linkages --help  # [unix]
+    - conda-inspect objects --help  # [osx]
+    - conda-metapackage --help
+    - conda-render --help
+    - conda-skeleton --help
+    - conda-debug --help
     # bdist_conda
     - python test_bdist_conda_setup.py bdist_conda --help
 


### PR DESCRIPTION
conda-build 24.1.0

**Destination channel:** defaults

### Links

- [{ticket_number}]() 
- [Upstream repository](https://github.com/conda/conda-build)
- [Upstream changelog/diff](https://github.com/conda/conda-build/releases/tag/24.1.0)
- Relevant dependency PRs:
  - n/a

### Explanation of changes:

- Bump to latest version
- Remove conda-index entrypoint
- Update entrypoints
- Update tests
