### PR TITLE
Build with python 3.12

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12


### PR DESCRIPTION
We forgot to build for python 3.12 in https://github.com/AnacondaRecipes/conda-build-feedstock/pull/38.