### PR TITLE
24.1.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda-build" %}
-{% set version = "24.1.0" %}
+{% set version = "24.1.1" %}
 {% set build_number = "0" %}
-{% set sha256 = "777430b8c85b1542df7bb10c140654d332a1fb37b219370151cd69dcbf073a88" %}
+{% set sha256 = "add8ccf7f5c1be96c2ac3d596e80a0dcd33bf9250fa759477292668904da4bb1" %}
 
 
 package:


### PR DESCRIPTION
conda-build 24.1.1

**Destination channel:** defaults

### Links

- [PKG-4028](https://anaconda.atlassian.net/browse/PKG-4028)
- [Upstream repository](https://github.com/conda/conda)
- [Upstream changelog/diff](https://github.com/conda/conda-build/releases/tag/24.1.1)
- Relevant dependency PRs:
  - N/A

### Explanation of changes:

- Bump to 24.1.1 to fix nonzero exit on success


[PKG-4028]: https://anaconda.atlassian.net/browse/PKG-4028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ