### PR TITLE
24.1.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda-build" %}
-{% set version = "24.1.1" %}
+{% set version = "24.1.2" %}
 {% set build_number = "0" %}
-{% set sha256 = "add8ccf7f5c1be96c2ac3d596e80a0dcd33bf9250fa759477292668904da4bb1" %}
+{% set sha256 = "4a93cfe56d40dee3e444d845f44feb9f0cc2ec8e9427a699341d5eb177961d29" %}
 
 
 package:
@@ -42,7 +42,7 @@ requirements:
     - cctools # [osx]
     - chardet
     - conda >=22.11.0
-    - conda-index
+    - conda-index >=0.4.0
     - conda-package-handling >=1.3
     - filelock
     - jinja2


### PR DESCRIPTION
conda-build 24.1.2

**Destination channel:** defaults

### Links

- [PKG-4080](https://anaconda.atlassian.net/browse/PKG-4080) 
- [Upstream repository](https://github.com/conda/conda-build/issues/5134)
- [Upstream changelog/diff](https://github.com/conda/conda-build/releases/tag/24.1.2)
- Relevant dependency PRs:
  - n/a

### Explanation of changes:

- Bump to 24.1.2
- Fix conda-index dependency per https://github.com/conda/conda-build/issues/5134#issuecomment-1946201244


[PKG-4080]: https://anaconda.atlassian.net/browse/PKG-4080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ