### PR TITLE
Bump to 24.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda-build" %}
-{% set version = "24.3.0" %}
+{% set version = "24.5.0" %}
 {% set build_number = "0" %}
-{% set sha256 = "961ecb2ab22179191cdacd9074afdc0f5ed50f10dc54577c5b8792798d0edce1" %}
+{% set sha256 = "97938c7940777d014ded9b3031e8ae0bf516e68937ffb4f43075ea5ffccc1d24" %}
 
 
 package:
@@ -41,10 +41,11 @@ requirements:
     - beautifulsoup4
     - cctools # [osx]
     - chardet
-    - conda >=23.5.0
+    - conda >=23.7.0
     - conda-index >=0.4.0
     - conda-package-handling >=1.3
     - filelock
+    - frozendict >=2.4.2
     - jinja2
     - jsonschema >=4.19
     - m2-patch  >=2.6   # [win]
@@ -74,8 +75,6 @@ test:
   requires:
     - setuptools
     - pip
-  files:
-    - test_bdist_conda_setup.py
   commands:
     - python -m pip check
     # subcommands
@@ -101,8 +100,6 @@ test:
     - conda-render --help
     - conda-skeleton --help
     - conda-debug --help
-    # bdist_conda
-    - python test_bdist_conda_setup.py bdist_conda --help
 
 about:
   home: https://github.com/conda/conda-build

--- a/recipe/test_bdist_conda_setup.py
+++ b/recipe/test_bdist_conda_setup.py
@@ -1,8 +1,0 @@
-from setuptools import setup
-import conda_build.bdist_conda
-
-setup(
-    name="package",
-    version="1.0.0",
-    distclass=conda_build.bdist_conda.CondaDistribution
-)


### PR DESCRIPTION
conda-build 24.5.0

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/conda/conda-build)
- [Upstream changelog/diff](https://github.com/conda/conda-build/releases/tag/24.5.0)
- Relevant dependency PRs/issues:
  - https://github.com/conda/conda-build/pull/5299
  - https://github.com/conda/conda-build/issues/5204