### PR TITLE
Bump conda-build version to 24.5.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda-build" %}
-{% set version = "24.5.0" %}
+{% set version = "24.5.1" %}
 {% set build_number = "0" %}
-{% set sha256 = "019a2893af9fb2e1aceed4ff66cabff35e0717195f25e90bed0dc1c119b4814a" %}
+{% set sha256 = "04fc40032bb35ea6b9bb18009643daf8f522e12a7e397516a9b2fa64b7f4927a" %}
 
 
 package:


### PR DESCRIPTION
🚧 _Please do not merge before Tuesday, May 28th_ 🚧

conda-build 24.5.1

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/conda/conda-build)
- [Upstream changelog/diff](https://github.com/conda/conda-build/releases/tag/24.5.1)
- https://github.com/conda/conda-build/issues/5319
- Relevant dependency PRs/issues:
  - https://github.com/conda/conda-build/issues/5342
  - https://github.com/conda/conda-build/issues/5267
