### PR TITLE
Bump conda-build to version 24.9.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda-build" %}
-{% set version = "24.7.1" %}
+{% set version = "24.9.0" %}
 {% set build_number = "0" %}
-{% set sha256 = "be805c420edaa2ad7626064c08d2767fd7e1bbc5e32309bb5a1f2a1058512078" %}
+{% set sha256 = "bc5d358f422fadeac7ec8d8fed499be0ee2cd3815ba1ab9c89db2081eebe6deb" %}
 
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,7 +73,7 @@ test:
     # updated submodules (can be dropped after 1-2 releases)
     - conda_build.index
   requires:
-    - setuptools
+    - setuptools <75.1.0  # temporary, see https://github.com/conda/conda-build/issues/5493
     - pip
   commands:
     - python -m pip check


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-5748](https://anaconda.atlassian.net/browse/PKG-5748)
- [Upstream repository](https://github.com/conda/conda-build)
- [Upstream changelog/diff](https://github.com/conda/conda-build/releases/tag/24.9.0)
- Relevant dependency PRs:
  - n/a

### Explanation of changes:

- https://github.com/conda/conda-build/issues/5481

[PKG-5748]: https://anaconda.atlassian.net/browse/PKG-5748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ