### PR TITLE
Bump conda-build version to 24.11.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda-build" %}
-{% set version = "24.11.0" %}
+{% set version = "24.11.1" %}
 {% set build_number = "0" %}
-{% set sha256 = "13cd2f453b53236cce90476b9743e128e955ac9dcffa095d7f578eed80635450" %}
+{% set sha256 = "1fafd20caa758862bb1b51cebf1bd87cf7c01cf41b7eaa5ed9d6de8e08e829c6" %}
 
 
 package:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-5748](https://anaconda.atlassian.net/browse/PKG-5748)
- [Upstream repository](https://github.com/conda/conda-build)
- [Upstream changelog/diff](https://github.com/conda/conda-build/releases/tag/24.11.1)
- Relevant dependency PRs:
  - https://github.com/conda/conda-build/pull/5550

### Explanation of changes:

- https://github.com/conda/conda-build/issues/5524

[PKG-5748]: https://anaconda.atlassian.net/browse/PKG-5748