### PR TITLE
Bump to 24.11.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda-build" %}
-{% set version = "24.11.1" %}
+{% set version = "24.11.2" %}
 {% set build_number = "0" %}
-{% set sha256 = "1fafd20caa758862bb1b51cebf1bd87cf7c01cf41b7eaa5ed9d6de8e08e829c6" %}
+{% set sha256 = "37aeb71e3bfc528299048a9fa1bd4afb63574be09cc84f7853c774fb2d9ba837" %}
 
 
 package:


### PR DESCRIPTION
conda-build 24.11.2

**Destination channel:** defaults

### Links

- [PKG-6329](https://anaconda.atlassian.net/browse/PKG-6329) 
- [Upstream repository](https://github.com/conda/conda-build/issues/5524)
- [Upstream changelog/diff](https://github.com/conda/conda-build/releases/tag/24.11.2)
- Relevant dependency PRs:
  - n/a

### Explanation of changes:

- patch resolving https://github.com/conda/conda-build/issues/5416


[PKG-6329]: https://anaconda.atlassian.net/browse/PKG-6329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ