### PR TITLE
Bump to 25.1.1.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda-build" %}
-{% set version = "24.11.2" %}
+{% set version = "25.1.1" %}
 {% set build_number = "0" %}
-{% set sha256 = "37aeb71e3bfc528299048a9fa1bd4afb63574be09cc84f7853c774fb2d9ba837" %}
+{% set sha256 = "a4fab906e6cbe3dc1a540012dc81500bbb99fe79be6454021042aa9a1d7f66ef" %}
 
 
 package:


### PR DESCRIPTION
conda-build 25.1.1

**Destination channel:** defaults

### Links

- [PKG-6766](https://anaconda.atlassian.net/browse/PKG-6766) 
- [Upstream repository](http://github.com/conda/conda-build)
- [Upstream changelog/diff](https://github.com/conda/conda-build/compare/24.11.2...25.1.1)

### Explanation of changes:

This includes the unreleased 25.1.0, which had some deprecations not removed and triggered deprecation exceptions for users


[PKG-6766]: https://anaconda.atlassian.net/browse/PKG-6766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ