### PR TITLE
conda-build 25.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,7 @@
 {% set name = "conda-build" %}
-{% set version = "25.1.2" %}
+{% set version = "25.3.0" %}
 {% set build_number = "0" %}
-{% set sha256 = "417e5e87d04adff677ea8782941e7f50771ee25681fd30e1a3ae9cffbc5132d3" %}
-
+{% set sha256 = "671db769bd8d783b3eac2ba7aae5b2f063e8a2ef2cf78d4ed396b927909dda6c" %}
 
 package:
   name: {{ name }}
@@ -52,7 +51,10 @@ requirements:
     - menuinst >=2
     - packaging
     - patch     >=2.6   # [not win]
-    - patchelf      # [linux]
+    # Cap to avoid bug where ELF load command is garbled.
+    # xref: https://github.com/conda/conda-build/issues/4881
+    # xref: https://github.com/NixOS/patchelf/issues/492
+    - patchelf <0.18    # [linux]
     - pkginfo
     - psutil
     - py-lief


### PR DESCRIPTION
conda-build 25.3.0

**Destination channel:** defaults

### Links

- [PKG-7430](https://anaconda.atlassian.net/browse/PKG-7430)
- [Upstream repository](https://github.com/conda/conda-build/issues/5632)
- [Upstream changelog/diff](https://github.com/conda/conda-build/releases/tag/25.3.0)
- Relevant dependency PRs:
  - n/a

### Explanation of changes:

- Latest version of `conda-build`


[PKG-7430]: https://anaconda.atlassian.net/browse/PKG-7430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ