### PR TITLE
conda-build 25.4.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda-build" %}
-{% set version = "25.3.2" %}
+{% set version = "25.4.2" %}
 {% set build_number = "0" %}
-{% set sha256 = "d8d684259d8b0c1204a5b01fd886da9637e21776695f784b26b42d7476da135b" %}
+{% set sha256 = "3444d39acb65c0d87d8d3318cca2e6b7faa88cc37e34e9025e29430be2be9626" %}
 
 package:
   name: {{ name }}
@@ -43,6 +43,7 @@ requirements:
     - conda >=23.7.0
     - conda-index >=0.4.0
     - conda-package-handling >=2.2.0
+    - evalidate >=2,<3.0a0
     - filelock
     - frozendict >=2.4.2
     - jinja2


### PR DESCRIPTION
conda-build 25.4.2

**Destination channel:** defaults

### Links

- [PKG-8027](https://anaconda.atlassian.net/browse/PKG-8027) 
- [Upstream repository](https://github.com/conda/conda-build/issues/5670)
- [Upstream changelog/diff](https://github.com/conda/conda-build/releases/tag/25.4.2)
- Relevant dependency PRs:
  - n/a

### Explanation of changes:

- April release with security patches


[PKG-8027]: https://anaconda.atlassian.net/browse/PKG-8027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ