### PR TITLE
conda-build 25.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - beautifulsoup4
     - cctools # [osx]
     - chardet
-    - conda >=23.7.0
+    - conda >=24.11.0
     - conda-index >=0.4.0
     - conda-package-handling >=2.2.0
     - evalidate >=2,<3.0a0
@@ -49,7 +49,6 @@ requirements:
     - jinja2
     - jsonschema >=4.19
     - m2-patch  >=2.6   # [win]
-    - menuinst >=2
     - packaging
     - patch     >=2.6   # [not win]
     # Cap to avoid bug where ELF load command is garbled.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda-build" %}
-{% set version = "25.4.2" %}
-{% set build_number = "1" %}
-{% set sha256 = "3444d39acb65c0d87d8d3318cca2e6b7faa88cc37e34e9025e29430be2be9626" %}
+{% set version = "25.5.0" %}
+{% set build_number = "0" %}
+{% set sha256 = "b1a0956d0beac42e54d0ee81b0cbf506e2bae823420413e57c1fbb9ccbd1e729" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
conda-build 25.5.0

**Destination channel:** defaults

### Links
- [Upstream repository](https://github.com/conda/conda-build)
- [Upstream changelog/diff](https://github.com/conda/conda-build/releases/tag/25.5.0)

### Explanation of changes:

- This is the regularly scheduled May, 2025 release of conda-build.
