### PR TITLE
Bump to 26.1.0.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "conda-build" %}
-{% set version = "25.11.1" %}
+{% set version = "26.1.0" %}
 {% set build_number = "0" %}
-{% set sha256 = "c41e1163ff7de7301ead0889a733b5f73ed89fc6c4e8a18d45fa7b8e8ca3bc13" %}
+{% set sha256 = "61021a7d16e640c439248b76585055f498d95fa0db40131516b064141fecf7ba" %}
 
 package:
   name: {{ name }}
@@ -39,8 +39,9 @@ requirements:
     - beautifulsoup4
     - cctools # [osx]
     - chardet
-    - conda >=24.11.0
+    - conda >=25.11.0
     - conda-index >=0.4.0
+    - conda-libmamba-solver >=25.11.0
     - conda-package-handling >=2.2.0
     - evalidate >=2,<3.0a0
     - filelock

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,6 @@ requirements:
     - chardet
     - conda >=25.11.0
     - conda-index >=0.4.0
-    - conda-libmamba-solver >=25.11.0
     - conda-package-handling >=2.2.0
     - evalidate >=2,<3.0a0
     - filelock
@@ -67,6 +66,7 @@ requirements:
     - tqdm
   run_constrained:
     - conda-verify >=3.1.0
+    - conda-libmamba-solver >=25.11.0
 
 test:
   imports:


### PR DESCRIPTION
conda-build 26.1.0

**Destination channel:** defaults

### Links

- [PKG-12317](https://anaconda.atlassian.net/browse/PKG-12317) 
- [Upstream repository](https://github.com/conda/conda-build)
- [Upstream changelog/diff](https://github.com/conda/conda-build/releases/tag/26.1.0)
- Relevant dependency PRs:
  - https://github.com/conda/conda-build/pull/5905


[PKG-12317]: https://anaconda.atlassian.net/browse/PKG-12317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ