### PR TITLE
conda-build 26.7.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-build" %}
-{% set version = "26.5.0" %}
+{% set version = "26.7.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/conda/{{ name }}/releases/download/{{ version }}/{{ name }}-{{ version }}.tar.gz
-  sha256: ce2c9c2b8e620ab4e533f6e2207b5a0638c2c5575f1797dc8a8bf6e67c55c355
+  sha256: 92f349f2c3eb79a452bb35f592f40f57c9847c346c8289a3a71237206609970c
 
 build:
   skip: True  # [py<310]
@@ -51,7 +51,7 @@ requirements:
     - pkginfo
     - psutil
     - py-lief
-    - py-rattler-build >=0.61.4
+    - py-rattler-build >=0.65.1
     - python
     - python-libarchive-c
     - pyyaml


### PR DESCRIPTION
conda-build 26.7.0

**Destination channel:** defaults

### Links

- [PKG-16989](https://anaconda.atlassian.net/browse/PKG-16989)
- [Upstream repository](https://github.com/conda/conda-build)
- [Upstream changelog/diff](https://github.com/conda/conda-build/compare/26.5.0...26.7.0)
- Relevant dependency PRs:
  - [conda 26.7.0](https://github.com/AnacondaRecipes/conda-feedstock/pull/93)

### Explanation of changes:

- Updated conda-build from 26.5.0 to 26.7.0
- Raised `py-rattler-build` pin to `>=0.65.1`

[PKG-16989]: https://anaconda.atlassian.net/browse/PKG-16989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ