### PR TITLE
Win arm64 conda launchers

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/pbp/fs/conda-launchers-feedstock/pr2/96f77aa

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,3 @@
 channels:
   - https://staging.continuum.io/pbp/fs/conda-launchers-feedstock/pr2/96f77aa
+  - https://staging.continuum.io/pbp/fs/conda-launchers-feedstock/pr0/96f77aa

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,4 @@
 channels:
+  - bootstrap-win-arm64-round-2-native
   - https://staging.continuum.io/pbp/fs/conda-launchers-feedstock/pr2/96f77aa
   - https://staging.continuum.io/pbp/fs/conda-launchers-feedstock/pr0/96f77aa

--- a/recipe/0001-Add-win-arm64-support.patch
+++ b/recipe/0001-Add-win-arm64-support.patch
@@ -1,0 +1,152 @@
+From be32511dff1b42578a59e437359447ef21f344b7 Mon Sep 17 00:00:00 2001
+From: Eric Lundby <Eric.Lundby@gmail.com>
+Date: Mon, 19 Jan 2026 13:15:59 -0700
+Subject: [PATCH 1/1] Add win-arm64 support
+
+---
+ conda_build/convert.py                       |  7 +-
+ conda_build/launcher_sources/build_arm64.cmd | 81 ++++++++++++++++++++
+ conda_build/noarch_python.py                 |  2 +-
+ tests/test_codesigned.py                     |  3 +-
+ 4 files changed, 88 insertions(+), 5 deletions(-)
+ create mode 100644 conda_build/launcher_sources/build_arm64.cmd
+
+diff --git a/conda_build/convert.py b/conda_build/convert.py
+index 5b234364..432e7952 100644
+--- a/conda_build/convert.py
++++ b/conda_build/convert.py
+@@ -555,13 +555,14 @@ def create_exe_file(directory, executable, target_platform):
+     Positional arguments:
+     directory (str) -- the file path to the 'Scripts' directory
+     executable (str) -- the filename of the executable to create an exe file for
+-    target_platform -- the platform to target: 'win-64' or 'win-32'
++    target_platform -- the platform to target: 'win-64', 'win-32', or 'win-arm64'
+     """
+     exe_directory = os.path.dirname(__file__)
+ 
+-    if target_platform.endswith("32"):
++    if target_platform.endswith("arm64"):
++        executable_file = os.path.join(exe_directory, "cli-arm64.exe")
++    elif target_platform.endswith("32"):
+         executable_file = os.path.join(exe_directory, "cli-32.exe")
+-
+     else:
+         executable_file = os.path.join(exe_directory, "cli-64.exe")
+ 
+diff --git a/conda_build/launcher_sources/build_arm64.cmd b/conda_build/launcher_sources/build_arm64.cmd
+new file mode 100644
+index 00000000..ab46d0bd
+--- /dev/null
++++ b/conda_build/launcher_sources/build_arm64.cmd
+@@ -0,0 +1,81 @@
++@echo off
++REM Build script for ARM64 Windows launchers using VS2022
++REM Run this from an ARM64 Native Tools Command Prompt for VS 2022
++REM or after running: vcvarsall.bat arm64
++
++setlocal enabledelayedexpansion
++
++REM Check if we're in the right environment
++where cl.exe >nul 2>&1
++if %ERRORLEVEL% neq 0 (
++    echo ERROR: cl.exe not found. Please run from ARM64 Native Tools Command Prompt
++    echo or run: "C:\Program Files\Microsoft Visual Studio\2022\...\vcvarsall.bat" arm64
++    exit /b 1
++)
++
++REM Download launcher.c if not present
++if not exist launcher.c (
++    echo Downloading launcher.c from CPython 3.7...
++    curl -SLo launcher.c https://raw.githubusercontent.com/python/cpython/3.7/PC/launcher.c
++    if %ERRORLEVEL% neq 0 (
++        echo ERROR: Failed to download launcher.c
++        exit /b 1
++    )
++    
++    echo Applying patch...
++    git apply --verbose cpython-launcher-c-mods-for-setuptools.3.7.patch
++    if %ERRORLEVEL% neq 0 (
++        echo WARNING: git apply failed, trying patch command...
++        patch -p0 < cpython-launcher-c-mods-for-setuptools.3.7.patch
++    )
++)
++
++REM Create resource file
++echo Creating resources.rc...
++echo #include "winuser.h" > resources.rc
++echo 1 RT_MANIFEST manifest.xml >> resources.rc
++
++REM Compile resources
++echo Compiling resources...
++rc /nologo resources.rc
++if %ERRORLEVEL% neq 0 (
++    echo ERROR: Resource compilation failed
++    exit /b 1
++)
++
++REM Common compiler flags for size optimization
++set CFLAGS=/nologo /O1 /Os /MT /DNDEBUG /DSCRIPT_WRAPPER /DUNICODE /D_UNICODE /DWIN32_LEAN_AND_MEAN /GL /GS- /Gy
++set LFLAGS=/MACHINE:ARM64 /OPT:REF /OPT:ICF /LTCG advapi32.lib shell32.lib
++
++REM Build CLI version (console application)
++echo Building cli-arm64.exe...
++cl.exe %CFLAGS% launcher.c resources.res /link %LFLAGS% /SUBSYSTEM:CONSOLE /OUT:cli-arm64.exe
++if %ERRORLEVEL% neq 0 (
++    echo ERROR: Failed to build cli-arm64.exe
++    exit /b 1
++)
++
++REM Build GUI version (windows application)
++echo Building gui-arm64.exe...
++cl.exe %CFLAGS% /D_WINDOWS launcher.c resources.res /link %LFLAGS% /SUBSYSTEM:WINDOWS /OUT:gui-arm64.exe
++if %ERRORLEVEL% neq 0 (
++    echo ERROR: Failed to build gui-arm64.exe
++    exit /b 1
++)
++
++REM Show results
++echo.
++echo Build complete:
++dir /b *.exe 2>nul
++for %%F in (cli-arm64.exe gui-arm64.exe) do (
++    if exist %%F (
++        for %%A in (%%F) do echo   %%F: %%~zA bytes
++    )
++)
++
++echo.
++echo To install, copy cli-arm64.exe and gui-arm64.exe to:
++echo   conda_build\cli-arm64.exe
++echo   conda_build\gui-arm64.exe
++
++endlocal
+diff --git a/conda_build/noarch_python.py b/conda_build/noarch_python.py
+index 083ffeb0..352df2d2 100644
+--- a/conda_build/noarch_python.py
++++ b/conda_build/noarch_python.py
+@@ -144,7 +144,7 @@ def transform(m, files, prefix):
+ 
+     # copy in windows exe shims if there are any python-scripts
+     if d["python-scripts"]:
+-        for fn in "cli-32.exe", "cli-64.exe":
++        for fn in "cli-32.exe", "cli-64.exe", "cli-arm64.exe":
+             shutil.copyfile(join(this_dir, fn), join(prefix, fn))
+ 
+     # Read the local _link.py
+diff --git a/tests/test_codesigned.py b/tests/test_codesigned.py
+index 32489f40..230e24f6 100644
+--- a/tests/test_codesigned.py
++++ b/tests/test_codesigned.py
+@@ -87,7 +87,8 @@ def signtool_unsupported() -> bool:
+ 
+ @pytest.mark.skipif(signtool_unsupported(), reason=signtool_unsupported_because())
+ @pytest.mark.parametrize(
+-    "stub_file_name", ["cli-32.exe", "cli-64.exe", "gui-32.exe", "gui-64.exe"]
++    "stub_file_name",
++    ["cli-32.exe", "cli-64.exe", "cli-arm64.exe", "gui-32.exe", "gui-64.exe", "gui-arm64.exe"],
+ )
+ def test_stub_exe_signatures(stub_file_name: str) -> None:
+     """Verify that signtool verifies the signature of the stub exes"""
+-- 
+2.50.1 (Apple Git-155)
+

--- a/recipe/0001-Add-win-arm64-support.patch
+++ b/recipe/0001-Add-win-arm64-support.patch
@@ -1,16 +1,19 @@
-From be32511dff1b42578a59e437359447ef21f344b7 Mon Sep 17 00:00:00 2001
+From efcecc3524731db813c612fdd7165a23496be98f Mon Sep 17 00:00:00 2001
 From: Eric Lundby <Eric.Lundby@gmail.com>
-Date: Mon, 19 Jan 2026 13:15:59 -0700
-Subject: [PATCH 1/1] Add win-arm64 support
+Date: Wed, 12 Aug 2026 13:38:11 -0600
+Subject: [PATCH 1/2] Add win-arm64 support for convert and legacy noarch paths
 
+Teach conda convert and legacy noarch_python packaging to select and
+ship cli-arm64.exe stubs when targeting win-arm64. Extend codesign
+tests to cover ARM64 launcher binaries.
 ---
- conda_build/convert.py                       |  7 +-
- conda_build/noarch_python.py                 |  2 +-
- tests/test_codesigned.py                     |  3 +-
+ conda_build/convert.py       | 7 ++++---
+ conda_build/noarch_python.py | 2 +-
+ tests/test_codesigned.py     | 3 ++-
  3 files changed, 7 insertions(+), 5 deletions(-)
 
 diff --git a/conda_build/convert.py b/conda_build/convert.py
-index 5b234364..432e7952 100644
+index 5b23436..432e795 100644
 --- a/conda_build/convert.py
 +++ b/conda_build/convert.py
 @@ -555,13 +555,14 @@ def create_exe_file(directory, executable, target_platform):
@@ -32,7 +35,7 @@ index 5b234364..432e7952 100644
          executable_file = os.path.join(exe_directory, "cli-64.exe")
  
 diff --git a/conda_build/noarch_python.py b/conda_build/noarch_python.py
-index 083ffeb0..352df2d2 100644
+index 083ffeb..352df2d 100644
 --- a/conda_build/noarch_python.py
 +++ b/conda_build/noarch_python.py
 @@ -144,7 +144,7 @@ def transform(m, files, prefix):
@@ -45,7 +48,7 @@ index 083ffeb0..352df2d2 100644
  
      # Read the local _link.py
 diff --git a/tests/test_codesigned.py b/tests/test_codesigned.py
-index 32489f40..230e24f6 100644
+index 32489f4..230e24f 100644
 --- a/tests/test_codesigned.py
 +++ b/tests/test_codesigned.py
 @@ -87,7 +87,8 @@ def signtool_unsupported() -> bool:

--- a/recipe/0001-Add-win-arm64-support.patch
+++ b/recipe/0001-Add-win-arm64-support.patch
@@ -5,11 +5,9 @@ Subject: [PATCH 1/1] Add win-arm64 support
 
 ---
  conda_build/convert.py                       |  7 +-
- conda_build/launcher_sources/build_arm64.cmd | 81 ++++++++++++++++++++
  conda_build/noarch_python.py                 |  2 +-
  tests/test_codesigned.py                     |  3 +-
- 4 files changed, 88 insertions(+), 5 deletions(-)
- create mode 100644 conda_build/launcher_sources/build_arm64.cmd
+ 3 files changed, 7 insertions(+), 5 deletions(-)
 
 diff --git a/conda_build/convert.py b/conda_build/convert.py
 index 5b234364..432e7952 100644
@@ -33,93 +31,6 @@ index 5b234364..432e7952 100644
      else:
          executable_file = os.path.join(exe_directory, "cli-64.exe")
  
-diff --git a/conda_build/launcher_sources/build_arm64.cmd b/conda_build/launcher_sources/build_arm64.cmd
-new file mode 100644
-index 00000000..ab46d0bd
---- /dev/null
-+++ b/conda_build/launcher_sources/build_arm64.cmd
-@@ -0,0 +1,81 @@
-+@echo off
-+REM Build script for ARM64 Windows launchers using VS2022
-+REM Run this from an ARM64 Native Tools Command Prompt for VS 2022
-+REM or after running: vcvarsall.bat arm64
-+
-+setlocal enabledelayedexpansion
-+
-+REM Check if we're in the right environment
-+where cl.exe >nul 2>&1
-+if %ERRORLEVEL% neq 0 (
-+    echo ERROR: cl.exe not found. Please run from ARM64 Native Tools Command Prompt
-+    echo or run: "C:\Program Files\Microsoft Visual Studio\2022\...\vcvarsall.bat" arm64
-+    exit /b 1
-+)
-+
-+REM Download launcher.c if not present
-+if not exist launcher.c (
-+    echo Downloading launcher.c from CPython 3.7...
-+    curl -SLo launcher.c https://raw.githubusercontent.com/python/cpython/3.7/PC/launcher.c
-+    if %ERRORLEVEL% neq 0 (
-+        echo ERROR: Failed to download launcher.c
-+        exit /b 1
-+    )
-+    
-+    echo Applying patch...
-+    git apply --verbose cpython-launcher-c-mods-for-setuptools.3.7.patch
-+    if %ERRORLEVEL% neq 0 (
-+        echo WARNING: git apply failed, trying patch command...
-+        patch -p0 < cpython-launcher-c-mods-for-setuptools.3.7.patch
-+    )
-+)
-+
-+REM Create resource file
-+echo Creating resources.rc...
-+echo #include "winuser.h" > resources.rc
-+echo 1 RT_MANIFEST manifest.xml >> resources.rc
-+
-+REM Compile resources
-+echo Compiling resources...
-+rc /nologo resources.rc
-+if %ERRORLEVEL% neq 0 (
-+    echo ERROR: Resource compilation failed
-+    exit /b 1
-+)
-+
-+REM Common compiler flags for size optimization
-+set CFLAGS=/nologo /O1 /Os /MT /DNDEBUG /DSCRIPT_WRAPPER /DUNICODE /D_UNICODE /DWIN32_LEAN_AND_MEAN /GL /GS- /Gy
-+set LFLAGS=/MACHINE:ARM64 /OPT:REF /OPT:ICF /LTCG advapi32.lib shell32.lib
-+
-+REM Build CLI version (console application)
-+echo Building cli-arm64.exe...
-+cl.exe %CFLAGS% launcher.c resources.res /link %LFLAGS% /SUBSYSTEM:CONSOLE /OUT:cli-arm64.exe
-+if %ERRORLEVEL% neq 0 (
-+    echo ERROR: Failed to build cli-arm64.exe
-+    exit /b 1
-+)
-+
-+REM Build GUI version (windows application)
-+echo Building gui-arm64.exe...
-+cl.exe %CFLAGS% /D_WINDOWS launcher.c resources.res /link %LFLAGS% /SUBSYSTEM:WINDOWS /OUT:gui-arm64.exe
-+if %ERRORLEVEL% neq 0 (
-+    echo ERROR: Failed to build gui-arm64.exe
-+    exit /b 1
-+)
-+
-+REM Show results
-+echo.
-+echo Build complete:
-+dir /b *.exe 2>nul
-+for %%F in (cli-arm64.exe gui-arm64.exe) do (
-+    if exist %%F (
-+        for %%A in (%%F) do echo   %%F: %%~zA bytes
-+    )
-+)
-+
-+echo.
-+echo To install, copy cli-arm64.exe and gui-arm64.exe to:
-+echo   conda_build\cli-arm64.exe
-+echo   conda_build\gui-arm64.exe
-+
-+endlocal
 diff --git a/conda_build/noarch_python.py b/conda_build/noarch_python.py
 index 083ffeb0..352df2d2 100644
 --- a/conda_build/noarch_python.py

--- a/recipe/0002-Fix-win-arm64-console-script-launchers.patch
+++ b/recipe/0002-Fix-win-arm64-console-script-launchers.patch
@@ -1,8 +1,25 @@
+From 6f88eaa0ea19d729aef0c6130f73be1423afcb93 Mon Sep 17 00:00:00 2001
+From: Eric Lundby <Eric.Lundby@gmail.com>
+Date: Wed, 12 Aug 2026 13:38:17 -0600
+Subject: [PATCH 2/2] Fix win-arm64 console script launchers
+
+Resolve Windows CLI launcher stubs from conda-launchers when installed,
+with fallback to stubs bundled in conda-build. Replace pip/distlib
+console-script executables (hard-coded build prefixes) with relocatable
+stubs after install, including on win-arm64.
+---
+ conda_build/build.py                  |   4 +
+ conda_build/utils.py                  |   4 +-
+ conda_build/windows.py                | 147 +++++++++++++++++++++++++-
+ tests/test_windows_console_scripts.py |  75 +++++++++++++
+ 4 files changed, 228 insertions(+), 2 deletions(-)
+ create mode 100644 tests/test_windows_console_scripts.py
+
 diff --git a/conda_build/build.py b/conda_build/build.py
-index 4441c4a..55da44a 100644
+index da865f7..92e78c9 100644
 --- a/conda_build/build.py
 +++ b/conda_build/build.py
-@@ -1639,6 +1639,10 @@ def post_process_files(m: MetaData, initial_prefix_files):
+@@ -1644,6 +1644,10 @@ def post_process_files(m: MetaData, initial_prefix_files):
      # this is new-style noarch, with a value of 'python'
      if m.noarch != "python":
          utils.create_entry_points(m.get_value("build/entry_points"), config=m.config)
@@ -14,10 +31,10 @@ index 4441c4a..55da44a 100644
  
      python = (
 diff --git a/conda_build/utils.py b/conda_build/utils.py
-index b4489cf..42393b8 100644
+index 8105514..da2567a 100644
 --- a/conda_build/utils.py
 +++ b/conda_build/utils.py
-@@ -1081,6 +1081,8 @@ def iter_entry_points(items):
+@@ -1083,6 +1083,8 @@ def iter_entry_points(items):
  
  def create_entry_point(path, module, func, config):
      """Creates an entry point for legacy noarch_python builds"""
@@ -26,7 +43,7 @@ index b4489cf..42393b8 100644
      import_name = func.split(".")[0]
      pyscript = PY_TMPL % {"module": module, "func": func, "import_name": import_name}
      if on_win:
-@@ -1089,7 +1091,7 @@ def create_entry_point(path, module, func, config):
+@@ -1091,7 +1093,7 @@ def create_entry_point(path, module, func, config):
                  fo.write("#!python_d\n")
              fo.write(pyscript)
              copy_into(
@@ -36,10 +53,10 @@ index b4489cf..42393b8 100644
                  config.timeout,
              )
 diff --git a/conda_build/windows.py b/conda_build/windows.py
-index f9234f9..83cfe9c 100644
+index 4302b39..caab30e 100644
 --- a/conda_build/windows.py
 +++ b/conda_build/windows.py
-@@ -20,6 +20,7 @@ except:
+@@ -31,6 +31,7 @@ except:
      pass
  
  from . import environ
@@ -47,7 +64,7 @@ index f9234f9..83cfe9c 100644
  from .utils import (
      check_call_env,
      copy_into,
-@@ -42,6 +43,150 @@ VS_VERSION_STRING = {
+@@ -53,6 +54,150 @@ VS_VERSION_STRING = {
  }
  
  
@@ -198,7 +215,7 @@ index f9234f9..83cfe9c 100644
  def fix_staged_scripts(scripts_dir, config):
      """
      Fixes scripts which have been installed unix-style to have a .bat
-@@ -66,7 +191,7 @@ def fix_staged_scripts(scripts_dir, config):
+@@ -77,7 +222,7 @@ def fix_staged_scripts(scripts_dir, config):
                  fo.write(f.read())
              # now create the .exe file
              copy_into(
@@ -288,3 +305,6 @@ index 0000000..94059f5
 +        assert os.path.isfile(os.path.join(scripts, "pkg-script.py"))
 +    finally:
 +        shutil.rmtree(tmpdir, ignore_errors=True)
+-- 
+2.50.1 (Apple Git-155)
+

--- a/recipe/0002-Fix-win-arm64-console-script-launchers.patch
+++ b/recipe/0002-Fix-win-arm64-console-script-launchers.patch
@@ -47,15 +47,35 @@ index f9234f9..83cfe9c 100644
  from .utils import (
      check_call_env,
      copy_into,
-@@ -42,6 +43,130 @@ VS_VERSION_STRING = {
+@@ -42,6 +43,150 @@ VS_VERSION_STRING = {
  }
  
  
++def _conda_launchers_dir():
++    """Return share/conda-launchers from an installed conda-launchers package."""
++    import sys
++
++    prefixes = []
++    for prefix in (os.environ.get("CONDA_PREFIX"), sys.prefix):
++        if prefix and prefix not in prefixes:
++            prefixes.append(prefix)
++    for prefix in prefixes:
++        launchers_dir = join(prefix, "share", "conda-launchers")
++        if isdir(launchers_dir):
++            return launchers_dir
++    return None
++
++
 +def get_windows_cli_launcher(config):
 +    """Return the path to the CLI launcher stub for the current host platform."""
 +    log = get_logger(__name__)
 +    exe_directory = dirname(__file__)
 +    arch = str(config.host_arch)
++    launchers_dir = _conda_launchers_dir()
++    if launchers_dir:
++        launcher = join(launchers_dir, f"cli-{arch}.exe")
++        if isfile(launcher):
++            return launcher
 +    launcher = join(exe_directory, f"cli-{arch}.exe")
 +    if isfile(launcher):
 +        return launcher

--- a/recipe/0002-Fix-win-arm64-console-script-launchers.patch
+++ b/recipe/0002-Fix-win-arm64-console-script-launchers.patch
@@ -1,0 +1,270 @@
+diff --git a/conda_build/build.py b/conda_build/build.py
+index 4441c4a..55da44a 100644
+--- a/conda_build/build.py
++++ b/conda_build/build.py
+@@ -1639,6 +1639,10 @@ def post_process_files(m: MetaData, initial_prefix_files):
+     # this is new-style noarch, with a value of 'python'
+     if m.noarch != "python":
+         utils.create_entry_points(m.get_value("build/entry_points"), config=m.config)
++    if utils.on_win:
++        from .windows import fix_windows_console_scripts
++
++        fix_windows_console_scripts(join(host_prefix, "Scripts"), m.config)
+     current_prefix_files = utils.prefix_files(prefix=host_prefix)
+ 
+     python = (
+diff --git a/conda_build/utils.py b/conda_build/utils.py
+index b4489cf..42393b8 100644
+--- a/conda_build/utils.py
++++ b/conda_build/utils.py
+@@ -1081,6 +1081,8 @@ def iter_entry_points(items):
+ 
+ def create_entry_point(path, module, func, config):
+     """Creates an entry point for legacy noarch_python builds"""
++    from .windows import get_windows_cli_launcher
++
+     import_name = func.split(".")[0]
+     pyscript = PY_TMPL % {"module": module, "func": func, "import_name": import_name}
+     if on_win:
+@@ -1089,7 +1091,7 @@ def create_entry_point(path, module, func, config):
+                 fo.write("#!python_d\n")
+             fo.write(pyscript)
+             copy_into(
+-                join(dirname(__file__), f"cli-{str(config.host_arch)}.exe"),
++                get_windows_cli_launcher(config),
+                 path + ".exe",
+                 config.timeout,
+             )
+diff --git a/conda_build/windows.py b/conda_build/windows.py
+index f9234f9..83cfe9c 100644
+--- a/conda_build/windows.py
++++ b/conda_build/windows.py
+@@ -20,6 +20,7 @@ except:
+     pass
+ 
+ from . import environ
++from .exceptions import CondaBuildException
+ from .utils import (
+     check_call_env,
+     copy_into,
+@@ -42,6 +43,130 @@ VS_VERSION_STRING = {
+ }
+ 
+ 
++def get_windows_cli_launcher(config):
++    """Return the path to the CLI launcher stub for the current host platform."""
++    log = get_logger(__name__)
++    exe_directory = dirname(__file__)
++    arch = str(config.host_arch)
++    launcher = join(exe_directory, f"cli-{arch}.exe")
++    if isfile(launcher):
++        return launcher
++    if arch == "arm64" and isfile(join(exe_directory, "cli-64.exe")):
++        log.warning(
++            "cli-arm64.exe not found; falling back to cli-64.exe "
++            "(runs under x64 emulation on Windows ARM64)"
++        )
++        return join(exe_directory, "cli-64.exe")
++    raise CondaBuildException(
++        f"Cannot find Windows CLI launcher stub cli-{arch}.exe in conda-build."
++    )
++
++
++def _strip_python_shebang_from_script(script_path):
++    with open(script_path, "rb") as f:
++        data = f.read()
++    if not data.startswith(b"#!"):
++        return
++    newline = b"\n" if b"\n" in data.splitlines(True)[0] else b"\r\n"
++    first_line_end = data.find(newline)
++    if first_line_end == -1 or b"python" not in data[:first_line_end].lower():
++        return
++    print(f"Removing hard-coded shebang from {os.path.basename(script_path)}")
++    with open(script_path, "wb") as f:
++        f.write(data[first_line_end + len(newline) :])
++
++
++def _extract_script_from_pip_launcher(exe_path):
++    """Extract the Python script embedded in pip's zip-based Windows launcher."""
++    with open(exe_path, "rb") as f:
++        data = f.read()
++    marker = b"__main__.py"
++    idx = 0
++    while True:
++        idx = data.find(marker, idx)
++        if idx == -1:
++            return None
++        start = idx + len(marker)
++        # Skip zip central-directory entries where the marker is not followed by code.
++        if data.startswith(b"PK", start):
++            idx = start
++            continue
++        end = data.find(b"\nPK", start)
++        if end == -1:
++            end = data.find(b"PK\x05\x06", start)
++        if end == -1:
++            end = len(data)
++        try:
++            script = data[start:end].decode("utf-8")
++        except UnicodeDecodeError:
++            idx = start
++            continue
++        if script.strip():
++            return script
++        idx = start
++
++
++def _exe_has_build_prefix(exe_data, prefix_variants):
++    if b"_h_env" in exe_data:
++        return True
++    return any(v.encode("utf-8") in exe_data for v in prefix_variants)
++
++
++def fix_windows_console_scripts(scripts_dir, config):
++    """Replace pip/distlib console script launchers with relocatable CLI stubs."""
++    if not isdir(scripts_dir):
++        return
++
++    launcher = get_windows_cli_launcher(config)
++    prefix = config.host_prefix
++    prefix_u = prefix.replace("\\", "/")
++    prefix_variants = {
++        prefix,
++        prefix_u,
++        prefix[0].upper() + prefix[1:],
++        prefix[0].lower() + prefix[1:],
++        prefix_u[0].upper() + prefix_u[1:],
++        prefix_u[0].lower() + prefix_u[1:],
++    }
++
++    for fn in os.listdir(scripts_dir):
++        if not fn.endswith(".exe") or not isfile(join(scripts_dir, fn)):
++            continue
++
++        exe_path = join(scripts_dir, fn)
++        script_path = join(scripts_dir, fn[:-4] + "-script.py")
++
++        with open(exe_path, "rb") as f:
++            exe_data = f.read()
++
++        # pip/distlib launchers are much larger than conda-build's ~50KB stubs.
++        is_pip_launcher = len(exe_data) > 100000 or _exe_has_build_prefix(
++            exe_data, prefix_variants
++        )
++        if not is_pip_launcher:
++            if isfile(script_path):
++                _strip_python_shebang_from_script(script_path)
++            continue
++
++        print(f"Fixing Windows console script launcher: {fn}")
++        if not isfile(script_path):
++            extracted = _extract_script_from_pip_launcher(exe_path)
++            if extracted:
++                with open(script_path, "w", encoding="utf-8") as fo:
++                    fo.write(extracted)
++            else:
++                log = get_logger(__name__)
++                log.warning(
++                    "Could not extract script for %s; declare build/entry_points "
++                    "in meta.yaml or ensure a matching *-script.py exists",
++                    fn,
++                )
++                continue
++
++        _strip_python_shebang_from_script(script_path)
++        copy_into(launcher, exe_path, config.timeout)
++
++
+ def fix_staged_scripts(scripts_dir, config):
+     """
+     Fixes scripts which have been installed unix-style to have a .bat
+@@ -66,7 +191,7 @@ def fix_staged_scripts(scripts_dir, config):
+                 fo.write(f.read())
+             # now create the .exe file
+             copy_into(
+-                join(dirname(__file__), f"cli-{config.host_arch}.exe"),
++                get_windows_cli_launcher(config),
+                 join(scripts_dir, fn + ".exe"),
+             )
+ 
+diff --git a/tests/test_windows_console_scripts.py b/tests/test_windows_console_scripts.py
+new file mode 100644
+index 0000000..94059f5
+--- /dev/null
++++ b/tests/test_windows_console_scripts.py
+@@ -0,0 +1,75 @@
++import os
++import shutil
++import tempfile
++
++import pytest
++
++from conda_build.config import Config
++from conda_build.utils import on_win
++from conda_build.windows import (
++    _extract_script_from_pip_launcher,
++    fix_windows_console_scripts,
++    get_windows_cli_launcher,
++)
++
++
++@pytest.mark.skipif(not on_win, reason="Windows-only")
++def test_get_windows_cli_launcher_arm64_fallback():
++    config = Config()
++    config._host_arch = "arm64"
++    launcher = get_windows_cli_launcher(config)
++    assert os.path.isfile(launcher)
++    assert launcher.endswith(".exe")
++
++
++@pytest.mark.skipif(not on_win, reason="Windows-only")
++def test_extract_script_from_pip_launcher():
++    payload = (
++        b"prefix path _h_env\\python.exe\n"
++        b"PK\x03\x04\x14\x00\x00\x00\x00\x00"
++        b"__main__.pyimport sys\nprint('hi')\n"
++        b"PK\x01\x02"
++        b"__main__.pyPK\x05\x06"
++    )
++    with tempfile.NamedTemporaryFile(suffix=".exe", delete=False) as fo:
++        fo.write(payload)
++        path = fo.name
++    try:
++        extracted = _extract_script_from_pip_launcher(path)
++        assert extracted == "import sys\nprint('hi')\n"
++    finally:
++        os.unlink(path)
++
++
++@pytest.mark.skipif(not on_win, reason="Windows-only")
++def test_fix_windows_console_scripts_replaces_pip_launcher():
++    payload = (
++        b"MZ"
++        + b"\x00" * 182800
++        + b"C:\\build\\croot\\pkg_123\\_h_env\\python.exe\n"
++        b"PK\x03\x04\x14\x00\x00\x00\x00\x00"
++        b"__main__.pyimport sys\nfrom pkg import main\n"
++        b"if __name__ == '__main__':\n    main()\n"
++        b"PK\x01\x02"
++        b"__main__.pyPK\x05\x06"
++    )
++    tmpdir = tempfile.mkdtemp()
++    try:
++        scripts = os.path.join(tmpdir, "Scripts")
++        os.makedirs(scripts)
++        exe_path = os.path.join(scripts, "pkg.exe")
++        with open(exe_path, "wb") as fo:
++            fo.write(payload)
++
++        config = Config(croot=tmpdir)
++        config._host_prefix = tmpdir
++        config._host_arch = "arm64"
++
++        fix_windows_console_scripts(scripts, config)
++
++        data = open(exe_path, "rb").read()
++        assert b"_h_env" not in data
++        assert len(data) < 100000
++        assert os.path.isfile(os.path.join(scripts, "pkg-script.py"))
++    finally:
++        shutil.rmtree(tmpdir, ignore_errors=True)

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,15 @@
+:: Build ARM64 launcher executable
+pushd conda_build\launcher_sources
+curl -SLo launcher.c https://raw.githubusercontent.com/python/cpython/3.7/PC/launcher.c
+patch -p0 < cpython-launcher-c-mods-for-setuptools.3.7.patch
+
+echo #include "winuser.h" > resources.rc
+echo 1 RT_MANIFEST manifest.xml >> resources.rc
+rc /nologo resources.rc
+
+cl.exe /nologo /O1 /Os /MT /DNDEBUG /DSCRIPT_WRAPPER /DUNICODE /D_UNICODE /DWIN32_LEAN_AND_MEAN /GL /GS- /Gy launcher.c resources.res /link /MACHINE:ARM64 /SUBSYSTEM:CONSOLE /OPT:REF /OPT:ICF /LTCG advapi32.lib shell32.lib /OUT:cli-arm64.exe
+copy cli-arm64.exe ..\
+popd
+
+"%PYTHON%" -m pip install . -vv --no-deps --no-build-isolation
+if errorlevel 1 exit /b 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,7 +7,7 @@ echo #include "winuser.h" > resources.rc
 echo 1 RT_MANIFEST manifest.xml >> resources.rc
 rc /nologo resources.rc
 
-cl.exe /nologo /O1 /Os /MT /DNDEBUG /DSCRIPT_WRAPPER /DUNICODE /D_UNICODE /DWIN32_LEAN_AND_MEAN /GL /GS- /Gy launcher.c resources.res /link /MACHINE:ARM64 /SUBSYSTEM:CONSOLE /OPT:REF /OPT:ICF /LTCG advapi32.lib shell32.lib /OUT:cli-arm64.exe
+cl.exe /nologo /O1 /Os /MT /DNDEBUG /DSCRIPT_WRAPPER /DUNICODE /D_UNICODE /DWIN32_LEAN_AND_MEAN /GL /GS- /Gy launcher.c resources.res /link /MACHINE:ARM64 /SUBSYSTEM:CONSOLE /OPT:REF /OPT:ICF /LTCG advapi32.lib shell32.lib version.lib /OUT:cli-arm64.exe
 copy cli-arm64.exe ..\
 popd
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,15 +1,30 @@
-:: Build ARM64 launcher executable
-pushd conda_build\launcher_sources
-curl -SLo launcher.c https://raw.githubusercontent.com/python/cpython/3.7/PC/launcher.c
-patch -p0 < cpython-launcher-c-mods-for-setuptools.3.7.patch
-
-echo #include "winuser.h" > resources.rc
-echo 1 RT_MANIFEST manifest.xml >> resources.rc
-rc /nologo resources.rc
-
-cl.exe /nologo /O1 /Os /MT /DNDEBUG /DSCRIPT_WRAPPER /DUNICODE /D_UNICODE /DWIN32_LEAN_AND_MEAN /GL /GS- /Gy launcher.c resources.res /link /MACHINE:ARM64 /SUBSYSTEM:CONSOLE /OPT:REF /OPT:ICF /LTCG advapi32.lib shell32.lib version.lib /OUT:cli-arm64.exe
-copy cli-arm64.exe ..\
-popd
-
 "%PYTHON%" -m pip install . -vv --no-deps --no-build-isolation
 if errorlevel 1 exit /b 1
+
+REM Copy launchers from the conda-launchers host dependency into the package.
+set "ARCH_SUFFIX=64"
+if "%SUBDIR%"=="win-arm64" set "ARCH_SUFFIX=arm64"
+if "%SUBDIR%"=="win-32" set "ARCH_SUFFIX=32"
+
+set "LAUNCHER_SRC=%PREFIX%\share\conda-launchers"
+set "LAUNCHER_DST=%SP_DIR%\conda_build"
+
+if not exist "%LAUNCHER_SRC%\cli-%ARCH_SUFFIX%.exe" (
+    echo ERROR: missing %LAUNCHER_SRC%\cli-%ARCH_SUFFIX%.exe from conda-launchers
+    exit /b 1
+)
+
+copy /Y "%LAUNCHER_SRC%\cli-%ARCH_SUFFIX%.exe" "%LAUNCHER_DST%\"
+if errorlevel 1 exit /b 1
+copy /Y "%LAUNCHER_SRC%\gui-%ARCH_SUFFIX%.exe" "%LAUNCHER_DST%\"
+if errorlevel 1 exit /b 1
+
+REM win-64 builds also ship the native ARM64 launcher for cross-targeting.
+if "%SUBDIR%"=="win-64" (
+    if exist "%LAUNCHER_SRC%\cli-arm64.exe" (
+        copy /Y "%LAUNCHER_SRC%\cli-arm64.exe" "%LAUNCHER_DST%\"
+        if errorlevel 1 exit /b 1
+        copy /Y "%LAUNCHER_SRC%\gui-arm64.exe" "%LAUNCHER_DST%\"
+        if errorlevel 1 exit /b 1
+    )
+)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,11 +10,12 @@ package:
 source:
   url: https://github.com/conda/{{ name }}/releases/download/{{ version }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    - 0001-Add-win-arm64-support.patch
 
 build:
   skip: True  # [py<310]
   number: {{ build_number }}
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - conda-build = conda_build.cli.main_build:execute
     - conda-convert = conda_build.cli.main_convert:execute
@@ -30,6 +31,7 @@ requirements:
     # The build workers have cygwin git already installed so it is not necessary,
     # see https://github.com/anaconda-distribution/anaconda-linter/issues/189#issue-1568495905
     - git  # [not win]
+    - {{ compiler('cxx') }}  # [win]
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,8 +27,6 @@ build:
     - conda-skeleton = conda_build.cli.main_skeleton:execute
 
 requirements:
-  build:
-    - git
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   skip: True  # [py<310]
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv  # [not win]
   entry_points:
     - conda-build = conda_build.cli.main_build:execute
@@ -28,16 +28,15 @@ build:
 
 requirements:
   build:
-    # The build workers have cygwin git already installed so it is not necessary,
-    # see https://github.com/anaconda-distribution/anaconda-linter/issues/189#issue-1568495905
-    - git  # [not win]
-    - {{ compiler('cxx') }}  # [win]
+    - git
   host:
     - python
     - pip
     - hatchling >=1.12.2
     - hatch-vcs >=0.2.0
+    - conda-launchers 24.7.1.*  # [win]
   run:
+    - conda-launchers 24.7.1.*  # [win]
     - beautifulsoup4
     - cctools # [osx]
     - chardet

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,11 @@ source:
   sha256: ce2c9c2b8e620ab4e533f6e2207b5a0638c2c5575f1797dc8a8bf6e67c55c355
   patches:
     - 0001-Add-win-arm64-support.patch
+    - 0002-Fix-win-arm64-console-script-launchers.patch
 
 build:
   skip: True  # [py<310]
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv  # [not win]
   entry_points:
     - conda-build = conda_build.cli.main_build:execute


### PR DESCRIPTION
## Summary

Enable **win-arm64** for conda-build **26.7.0** by shipping native Windows launcher stubs and patching upstream so console scripts work on ARM64.

- Bump to **26.7.0** (merge from master) and **build number 2**.
- Add **`conda-launchers 24.7.1.*`** as Windows host/run dependency; **`bld.bat`** copies `cli-{arch}.exe` / `gui-{arch}.exe` from `share/conda-launchers` into `conda_build` (win-64 also ships ARM64 stubs for cross-targeting).
- Patch upstream for win-arm64: `convert` / legacy noarch paths, `get_windows_cli_launcher()`, and `fix_windows_console_scripts()` to replace pip’s prefix-hardcoded launchers.
- **`abs.yaml`:** bootstrap channel `bootstrap-win-arm64-round-2-native` plus staging channels for [conda-launchers PR #2](https://github.com/AnacondaRecipes/conda-launchers-feedstock/pull/2) (`96f77aa`).

## Context

Upstream 26.7.0 still only bundles 32/64 launcher stubs. Native win-arm64 bootstrap needs ARM64 stubs from conda-launchers and runtime logic to pick them up when building packages.

**Draft** — depends on conda-launchers source-build work landing in bootstrap before merge to main.